### PR TITLE
Performance: no broadcasting; reduced evaluations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# line profiler output
+*.lprof
+
 # Distribution / packaging
 .Python
 build/

--- a/Problems/square.py
+++ b/Problems/square.py
@@ -19,11 +19,33 @@ class Square(Problem):
         self.n = n
         self.m = 1
 
+        # Allocated vector for the response and derivatives, subsequent
+        # interations can reuse the storage.
+        self._g = None
+        self._dg = None
+        self._ddg = None
+
     def g(self, x):
-        return np.array([np.dot(x, x), 1-np.sum(x)])
+        if self._g is None:
+            self._g = np.array([np.dot(x, x), 1-np.sum(x)])
+        else:
+            self._g[0] = np.dot(x, x)
+            self._g[1] = 1 - np.sum(x)
+        return self._g
 
     def dg(self, x):
-        return np.array([2*x, -np.ones_like(x)])
+        if self._dg is None:
+            self._dg = np.array([2*x, -np.ones_like(x)])
+        else:
+            self._dg[0] = 2*x
+            self._dg[1] = -1
+        return self._dg
 
     def ddg(self, x):
-        return np.array([2*np.ones_like(x), np.zeros_like(x)])
+        if self._ddg is None:
+            self._ddg = np.array([2*np.ones_like(x), np.zeros_like(x)])
+        else:
+            self._ddg[0] = 2
+            self._ddg[1] = 0
+        return self._ddg
+

--- a/sao/approximations/intervening.py
+++ b/sao/approximations/intervening.py
@@ -164,35 +164,33 @@ class MMA(Intervening):
             self.upp = np.maximum(self.upp, uppmin)
 
     def y(self, x):
-        y = np.zeros_like(self.positive, dtype=float)
-        y[self.positive] = np.broadcast_to((1 / (self.upp - x)), self.positive.shape)[self.positive]
-        y[~self.positive] = np.broadcast_to((1 / (x - self.low)), self.positive.shape)[~self.positive]
+        # The first call to reciprocal will allocate the array, leaving the
+        # `~self.positive` undefined, which are then set by the second call
+        # overwriting the variable in place `out=y`.
+        y = np.reciprocal(self.upp - x, where=self.positive, dtype=float)
+        y = np.reciprocal(x - self.low, out=y, where=~self.positive)
         return y
 
     def dydx(self, x):
-        dydx = np.zeros_like(self.positive, dtype=float)
-        dydx[self.positive] = np.broadcast_to((1 / (self.upp - x)**2), self.positive.shape)[self.positive]
-        dydx[~self.positive] = np.broadcast_to((-1 / (x - self.low)**2), self.positive.shape)[~self.positive]
+        dydx = np.reciprocal((self.upp - x)**2, where=self.positive, dtype=float)
+        dydx = np.reciprocal(-(x - self.low)**2, out=dydx, where=~self.positive)
         return dydx
 
     def ddyddx(self, x):
-        ddyddx = np.zeros_like(self.positive, dtype=float)
-        ddyddx[self.positive] = np.broadcast_to((2 / (self.upp - x) ** 3), self.positive.shape)[self.positive]
-        ddyddx[~self.positive] = np.broadcast_to((2 / (x - self.low) ** 3), self.positive.shape)[~self.positive]
+        ddyddx = np.reciprocal(0.5 * (self.upp - x)**3, where=self.positive, dtype=float)
+        ddyddx = np.reciprocal(0.5 * (x - self.low)**3, out=ddyddx, where=~self.positive)
         return ddyddx
 
     # Define chain rule term: y = T_inv(x) --> x = T(x) --> dT/dy = dx/dy  (see ReferenceFiles/TaylorExpansion.pdf)
     def dxdy(self, x):
-        dxdy = np.zeros_like(self.positive, dtype=float)
-        dxdy[self.positive] = np.broadcast_to((1 / self.y(x) ** 2), self.positive.shape)[self.positive]
-        dxdy[~self.positive] = np.broadcast_to((-1 / self.y(x) ** 2), self.positive.shape)[~self.positive]
+        dxdy = np.reciprocal(+(self.y(x)**2), where=self.positive, dtype=float)
+        dxdy = np.reciprocal(-(self.y(x)**2), out=dxdy, where=~self.positive)
         return dxdy
 
     # Define chain rule 2nd-order term: y = T_inv(x) --> x = T(x) --> d^2T/dy^2 = d^2x/dy^2  (see TaylorExpansion.pdf)
     def ddxddy(self, x, **kwargs):
-        ddxddy = np.zeros_like(self.positive, dtype=float)
-        ddxddy[self.positive] = np.broadcast_to((-2 / self.y(x) ** 3), self.positive.shape)[self.positive]
-        ddxddy[~self.positive] = np.broadcast_to((2 / self.y(x) ** 3), self.positive.shape)[~self.positive]
+        ddxddy = np.reciprocal(-0.5 * self.y(x)**3, where=self.positive, dtype=float)
+        ddxddy = np.reciprocal(+0.5 * self.y(x)**3, out=ddxddy, where=self.positive)
         return ddxddy
 
     def get_move_limit(self):

--- a/sao/problems/subproblem.py
+++ b/sao/problems/subproblem.py
@@ -35,6 +35,22 @@ class Subproblem(Problem):
     def ddg(self, x):
         return self.approx.ddg(self.inter.y(x).T, self.inter.dydx(x), self.inter.ddyddx(x))
 
+    def g_dg(self, x):
+        # save repeatedly used computations
+        y = self.inter.y(x).T
+        dydx = self.inter.dydx(x)
+        return self.approx.g(y), self.approx.dg(y, dydx)
+
+    def g_dg_ddg(self, x):
+        # save repeatedly used computations
+        y = self.inter.y(x).T
+        dydx = self.inter.dydx(x)
+
+        g = self.approx.g(y)
+        dg = self.approx.dg(y, dydx)
+        ddg = self.approx.ddg(y, dydx, self.inter.ddyddx(x))
+        return g, dg, ddg
+
     '''
     P = dg_j/dy_ji = dg_j/dx_i * dx_i/dy_ji [(m+1) x n]
     Q = d^2g_j/dy_ji^2 = d^2g_j/dx_i^2 * (dx_i/dy_ji)^2 + dg_j/dx_i * d^2x_i/dy_ji^2 [(m+1) x n]

--- a/sao/solvers/gradient_based_optimizer.py
+++ b/sao/solvers/gradient_based_optimizer.py
@@ -7,17 +7,27 @@ class GBOpt(ABC):
     """
 
     def __init__(self, problem, **kwargs):
-        self.n = problem.n
-        self.m = problem.m
+        self.problem = problem
 
-        self.g = problem.g
-        self.dg = problem.dg
-        self.ddg = problem.ddg
-
-        self.alpha = problem.alpha
-        self.beta = problem.beta
+        self.n, self.m = self.problem.n, self.problem.m
+        self.alpha, self.beta = self.problem.alpha, self.problem.beta
 
         self.x0 = kwargs.get('x0', 0.5*(self.alpha + self.beta))
+
+    def g(self, x):
+        return self.problem.g(x)
+
+    def dg(self, x):
+        return self.problem.dg(x)
+
+    def ddg(self, x):
+        return self.problem.ddg(x)
+
+    def g_dg(self, x):
+        return self.problem.g_dg(x)
+
+    def g_dg_ddg(self, x):
+        return self.problem.g_dg_ddg(x)
 
     @abstractmethod
     def update(self):

--- a/sao/solvers/interior_point.py
+++ b/sao/solvers/interior_point.py
@@ -231,20 +231,22 @@ class InteriorPointX(InteriorPoint):
         r(lam)      = gi[x] - ri + si
         r(s)        = lam * si - e
         """
+
+        g = self.g(self.w[0])
         dg = self.dg(self.w[0])
+
         self.r[0] = dg[0] + self.w[3].dot(dg[1:]) - self.w[1] + self.w[2]
         self.r[1] = self.w[1] * (self.w[0] - self.alpha) - self.epsi
         self.r[2] = self.w[2] * (self.beta - self.w[0]) - self.epsi
-        self.r[3] = self.g(self.w[0])[1:] + self.w[4]
+        self.r[3] = g[1:] + self.w[4]
         self.r[4] = self.w[3] * self.w[4] - self.epsi
 
     def get_newton_direction(self):
         # Some calculations to omit repetitive calculations later on
         a = self.w[0] - self.alpha
         b = self.beta - self.w[0]
-        g = self.g(self.w[0])
-        dg = self.dg(self.w[0])
-        ddg = self.ddg(self.w[0])
+
+        g, dg, ddg = self.g_dg_ddg(self.w[0])
 
         # delta_lambda
         delta_lambda = g[1:] + self.epsi / self.w[3]
@@ -297,21 +299,21 @@ s.t.    gi[x] - yi <= ri,    i = 1...m         (constraints)
         aj <= xj <= bj  i = 1...n                       (bound constraints)
         yi >= 0                                         (bound constraints)
 
-Constant real numbers: 
+Constant real numbers:
 ci >= 0
 
 Further, let di = 1 and ci = "large", so that variables yi become relatively expensive.
 Typically, y = 0 in any optimal solution of Part, and the corresponding x is an optimal solution of P as well.
 
-The user should avoid "extremely large" value for ci (e.g. 10^10). 
-It is good practice to start with low values for ci (e.g. 10^3) 
+The user should avoid "extremely large" value for ci (e.g. 10^10).
+It is good practice to start with low values for ci (e.g. 10^3)
 and raise if not all yi* = 0. (star denotes optimal solution)
 
 
 Lagrangian L:
 
-L := g0[x] + sum(ci*yi) + 
-    sum(lami * (gi[x] - yi - ri)) + 
+L := g0[x] + sum(ci*yi) +
+    sum(lami * (gi[x] - yi - ri)) +
     sum(xsij*(aj - xj) + etaj*(xj - bj)) -
     sum(muj*yj)
 
@@ -320,8 +322,8 @@ xsij    >= 0    := Lagrange multipliers wrt     aj <= xj
 etaj    >= 0    := Lagrange multipliers wrt     xj <= bj
 muj     >= 0    := Lagrange multipliers wrt     yi >= 0
 
-L           = psi[x,lam] + 
-                sum(ci*yi - lami*(yi + ri) - mui*yi) + 
+L           = psi[x,lam] +
+                sum(ci*yi - lami*(yi + ri) - mui*yi) +
                 sum(alphaj * (aj - xj) + betaj * (xj - bj))
 psi[x,lam]  = g0[x] + sum(lami * gi[x])
 
@@ -420,9 +422,8 @@ class InteriorPointXY(InteriorPointX):
         # Some calculations to omit repetitive calculations later on
         a = self.w[0] - self.alpha
         b = self.beta - self.w[0]
-        g = self.g(self.w[0])
-        dg = self.dg(self.w[0])
-        ddg = self.ddg(self.w[0])
+
+        g, dg, ddg = self.g_dg_ddg(self.w[0])
 
         # delta_lambda
         delta_lambda = g[1:] - self.w[5] + self.epsi / self.w[3]
@@ -489,7 +490,7 @@ s.t.    gi[x] - ai * z - yi <= ri,    i = 1...m         (constraints)
         yi >= 0                                         (bound constraints)
         z >= 0
 
-Constant real numbers: 
+Constant real numbers:
 a0 > 0
 ai >= 0
 ci >= 0
@@ -506,15 +507,15 @@ Then z = 0 in any optimal solution of Part.
 Further, let di = 1 and ci = "large", so that variables yi become relatively expensive.
 Typically, y = 0 in any optimal solution of Part, and the corresponding x is an optimal solution of P as well.
 
-The user should avoid "extremely large" value for ci (e.g. 10^10). 
-It is good practice to start with low values for ci (e.g. 10^3) 
+The user should avoid "extremely large" value for ci (e.g. 10^10).
+It is good practice to start with low values for ci (e.g. 10^3)
 and raise if not all yi* = 0. (star denotes optimal solution)
 
 
 Lagrangian L:
 
-L := g0[x] + a0*z + sum(ci*yi + 0.5*di*yi^2) + 
-    sum(lami * (gi[x] - ai*z - yi - ri)) + 
+L := g0[x] + a0*z + sum(ci*yi + 0.5*di*yi^2) +
+    sum(lami * (gi[x] - ai*z - yi - ri)) +
     sum(xsij*(aj - xj) + etaj*(xj - bj)) -
     sum(muj*yj) - zeta*z
 
@@ -524,9 +525,9 @@ etaj    >= 0    := Lagrange multipliers wrt     xj <= bj
 muj     >= 0    := Lagrange multipliers wrt     yi >= 0
 zeta    >= 0    := Lagrange multiplier wrt      z >= 0
 
-L           = psi[x,lam] + 
-                sum(ci*yi + 0.5*di*yi^2 - lami*(ai*z + yi + ri) - mui*yi) + 
-                sum(alphaj * (aj - xj) + betaj * (xj - bj)) + 
+L           = psi[x,lam] +
+                sum(ci*yi + 0.5*di*yi^2 - lami*(ai*z + yi + ri) - mui*yi) +
+                sum(alphaj * (aj - xj) + betaj * (xj - bj)) +
                 (a0 - zeta)*z
 psi[x,lam]  = g0[x] + sum(lami * gi[x])
 
@@ -590,6 +591,7 @@ Subsequently we are left with a reduced system in terms of dx and dlam
 
 
 class InteriorPointXYZ(InteriorPointXY):
+
     def __init__(self, problem, **kwargs):
         super().__init__(problem, **kwargs)
 
@@ -636,9 +638,7 @@ class InteriorPointXYZ(InteriorPointXY):
         # Some calculations to omit repetitive calculations later on
         a = self.w[0] - self.alpha
         b = self.beta - self.w[0]
-        g = self.g(self.w[0])
-        dg = self.dg(self.w[0])
-        ddg = self.ddg(self.w[0])
+        g, dg, ddg = self.g_dg_ddg(self.w[0])
 
         # delta_lambda
         delta_lambda = g[1:] - self.a * self.w[7] - self.w[5] + self.epsi / self.w[3]
@@ -671,7 +671,7 @@ class InteriorPointXYZ(InteriorPointXY):
         else:
             dxdx = delta_x / diag_x
             Blam = delta_lambday - dxdx.dot(dg[1:].transpose())
-            Alam = diags(diag_lambday) + dg[1:].dot(diags(1 / diag_x) * dg[1:].transpose())  # calculate dx[lam]
+            Alam = diags(diag_lambday) + np.einsum("ki,i,ji->kj", dg[1:], 1/diag_x, dg[1:])  # calculate dx[lam]
 
             # solve for dlam
             X = np.linalg.solve(np.block([[Alam, self.a], [self.a.transpose(), -self.w[8] / self.w[7]]]), np.block([[Blam], [delta_z]]))

--- a/tests/problems/test_square.py
+++ b/tests/problems/test_square.py
@@ -2,14 +2,15 @@ import pytest
 import numpy as np
 import logging
 from Problems.square import Square
-from sao.approximations.taylor import Taylor1, Taylor2
-from sao.approximations.intervening import Linear, ConLin, MMA
+from sao.approximations.taylor import Taylor1
+from sao.approximations.intervening import ConLin, MMA
 from sao.move_limits.ml_intervening import MoveLimitIntervening
 from sao.problems.subproblem import Subproblem
 from sao.solvers.interior_point import InteriorPointX as ipx
 from sao.solvers.interior_point import InteriorPointXY as ipxy
 from sao.solvers.interior_point import InteriorPointXYZ as ipxyz
 from sao.solvers.SolverIP_Svanberg import SvanbergIP
+
 
 # Set options for logging data: https://www.youtube.com/watch?v=jxmzY9soFXg&ab_channel=CoreySchafer
 logger = logging.getLogger(__name__)
@@ -23,8 +24,6 @@ logger.addHandler(stream_handler)
 
 np.set_printoptions(precision=4)
 
-
-@pytest.mark.parametrize('n', [10])
 def test_square_Svanberg(n):
     logger.info("Solving test_square using Ipopt Svanberg")
 
@@ -139,7 +138,6 @@ def test_square_ipxy(n):
     logger.info('Alles goed!')
 
 
-@pytest.mark.parametrize('n', [10])
 def test_square_ipxyz(n):
     logger.info("Solving test_square using Ipopt xyz")
 


### PR DESCRIPTION
Some minor changes based on performance profiling using the `tests/problems/test_square.py` problem running only the `ipxyz` variant. 

Measurements on 8d982e23666a42530ef44f1f5560cf9a7eee89e7
```bash
# n = 20, for 20 iterations
Benchmark #1: python tests/problems/test_square.py
  Time (mean ± σ):     362.2 ms ±   3.6 ms    [User: 457.6 ms, System: 1051.8 ms]
  Range (min … max):   359.3 ms … 370.7 ms    10 runs

# n = 2000, for 20 iterations
Benchmark #1: python tests/problems/test_square.py
  Time (mean ± σ):      1.319 s ±  0.010 s    [User: 1.462 s, System: 1.187 s]
  Range (min … max):    1.302 s …  1.333 s    10 runs

# n = 20000, for 20 iterations
Benchmark #1: python tests/problems/test_square.py
  Time (mean ± σ):      8.163 s ±  0.124 s    [User: 12.904 s, System: 31.740 s]
  Range (min … max):    7.954 s …  8.397 s    10 runs
```

Measurements on 50b8a5cfe168fe07360f8deb93642cd275ec6d33
```bash
# n = 20, for 20 iterations
Benchmark #1: python tests/problems/test_square.py
  Time (mean ± σ):     304.4 ms ±   3.0 ms    [User: 365.4 ms, System: 840.7 ms]
  Range (min … max):   300.5 ms … 310.0 ms    10 runs

# n = 2000, for 20 iterations
Benchmark #1: python tests/problems/test_square.py
  Time (mean ± σ):     967.5 ms ±   9.1 ms    [User: 1.116 s, System: 1.204 s]
  Range (min … max):   951.5 ms … 980.3 ms    10 runs

# n = 20000, for 20 iterations
Benchmark #1: python tests/problems/test_square.py
  Time (mean ± σ):      5.840 s ±  0.034 s    [User: 9.251 s, System: 22.692 s]
  Range (min … max):    5.796 s …  5.908 s    10 runs
```

The improvement ranges from 10-30% or so, depending on the problem size. 

Changing `np.broadcast_to` to  `np.reciprocal` within MMA avoids broadcasting and some indexing by combining the `where=` and `out=` optional arguments. The first call now allocates the arrays, leaving `~self.positive` undefined, which is then updated by the second call in place. We could save some more allocations by storing these arrays within the classes, however, when doing that I ran into some bugs, so I have left that for another time for now. 

Secondly, I now added `g_dg` and `g_dg_ddg` to bundle the computation of `g, dg, ddg` calls. The evaluation of the approximated problem is repeated in these, and it seems typical that all of them are computed at the same time. So, combining these calls saves some repeated evaluations. The code is not the cleanest, so we might want to think about that structure a bit more. 

Finally, I also store the returned arrays by the problem, in this case `Square`. I will play around a bit more with this structure, as it would be great if we can layout the `Problem` in such a way that this is done automatically. For large problems it is quite costly to reallocate the design variables and sensitivity vectors every iteration (where I am assuming that Python does not do any smart tricks by reusing the allocations and is simply dropping the memory and reallocating. If it does do something smarter, this might have little benefits). 

Maybe @artofscience and @aatmdelissen you can take a brief look. I will try to clean it up more before actually merging into `dev` though. 