### PR TITLE
interface with `scipy` (updated version)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install flake8 numpy scipy
+          pip install flake8 numpy scipy cvxopt
           if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
       - name: Lint with flake8
         run: |

--- a/examples/polynomial2D.py
+++ b/examples/polynomial2D.py
@@ -6,7 +6,7 @@ from sao.intervening_variables import Linear, MMA, MMAsquared, MixedIntervening
 from sao.move_limits import Bounds, MoveLimit
 from sao.convergence_criteria import VariableChange
 from sao.util import Plot
-from sao.solvers import SvanbergIP, CVXOPT
+from sao.solvers import SvanbergIP, CVXOPT, SCIPY
 from util.plotter import Plot2, Plot3
 from Problems._2d.Polynomial_2D import Polynomial2D
 
@@ -216,7 +216,64 @@ def example_polynomial_2D_cvxopt():
     logger.info('Optimization loop converged!')
 
 
+def example_polynomial_2D_scipy():
+    logger.info("Solving test_poly using y=MMA and solver=Ipopt Svanberg")
+
+    # Instantiate problem
+    prob = Polynomial2D()
+
+    # Instantiate a non-mixed approximation scheme
+    subprob = Subproblem(approximation=Taylor1(MMA(prob.x_min, prob.x_max)))
+    subprob.set_limits([Bounds(prob.x_min, prob.x_max), MoveLimit(move_limit=0.1, dx=prob.x_max - prob.x_min)])
+
+    # Initialize design and iteration counter
+    x_k = np.array([2, 1.5])  # no constraint active, i.e. internal minimum (lower right)
+    itte = 0
+
+    # Instantiate solver
+    solver = SCIPY(prob.n, prob.m, x0=x_k)
+
+    # Instantiate convergence criterion
+    criterion = VariableChange(x_k)
+
+    # Instantiate plotter           # TODO: Change the 'criterion' to f'{criterion.__class__.__name__}'
+    plotter = Plot(['objective', 'constraint', 'criterion', 'max_constr_violation'], path="../../../../Desktop")
+    plotter2_flag = True
+    if plotter2_flag:
+        plotter2 = Plot2(prob)
+
+    # Optimization loop
+    while itte < 100:       # not criterion.converged:
+
+        # Evaluate responses and sensitivities at current point, i.e. g(X^(k)), dg(X^(k)), ddg(X^(k))
+        f = prob.g(x_k)
+        df = prob.dg(x_k)
+        ddf = prob.ddg(x_k) if isinstance(subprob.approx, Taylor2) else None
+
+        # Build approximate sub-problem at X^(k)
+        subprob.build(x_k, f, df, ddf)
+
+        # Plot current approximation
+        if plotter2_flag:
+            # plotter2.plot_pair(x_k, f, prob, subprob, itte)
+            plotter2.contour_plot(x_k, f, prob, subprob, itte)
+
+        # Call solver (x_k, g and dg are within approx instance)
+        x_k = solver.subsolv(subprob)
+
+        # Print & Plot              # TODO: Print and Plot the criterion as criterion.value (where 0 is now)
+        logger.info(
+            'iter: {:^4d}  |  x: {:<10s}  |  obj: {:^9.3f}  |  criterion: {:^6.3f}  |  max_constr_viol: {:^6.3f}'.format(
+                itte, np.array2string(x_k[0]), f[0], 0, max(0, max(f[1:]))))
+        plotter.plot([f[0], f[1], 0, max(0, max(f[1:]))])
+
+        itte += 1
+
+    logger.info('Optimization loop converged!')
+
+
 if __name__ == "__main__":
     # example_polynomial_2D()
     # example_polynomial_2D_mixed()
-    example_polynomial_2D_cvxopt()
+    # example_polynomial_2D_cvxopt()
+    example_polynomial_2D_scipy()

--- a/sao/solvers/SolverIP_Svanberg.py
+++ b/sao/solvers/SolverIP_Svanberg.py
@@ -4,9 +4,9 @@ import numpy as np
 
 ## Svanberg's InteriorPoint solver found in http://www.ingveh.ulg.ac.be/uploads/education/meca-0027-1/MMA_DCAMM_1998.pdf
 def ipsolver(problem, x0=None, epsimin=1e-6, max_inner_iter=20, max_lines_iter=20, max_outer_iter=100,
-            epsifac=0.9, epsired=0.1, cCoef=1000):
+             epsifac=0.9, epsired=0.1, cCoef=1000):
     """
-    This function ipsolver solves the approximate problem P:
+    This function solves a problem P:
 
     minimize
 
@@ -24,7 +24,7 @@ def ipsolver(problem, x0=None, epsimin=1e-6, max_inner_iter=20, max_lines_iter=2
         z \\geq 0
 
     Input:  problem
-    Output: x, y, z, lam, xsi, eta, mu, zet, s
+    Output: x
     """
 
     # Initialization of parameters (once per design iteration)

--- a/sao/solvers/SolverIP_Svanberg.py
+++ b/sao/solvers/SolverIP_Svanberg.py
@@ -3,209 +3,193 @@ import numpy as np
 
 
 ## Svanberg's InteriorPoint solver found in http://www.ingveh.ulg.ac.be/uploads/education/meca-0027-1/MMA_DCAMM_1998.pdf
-class SvanbergIP:
-    def __init__(self, n, m):
-        self.n = n
-        self.m = m
-        self.epsimin = 1e-6
-        self.maxittt = 20
-        self.counter = 0
-        self.cCoef = 1000
+def ipsolver(problem, x0=None, epsimin=1e-6, max_inner_iter=20, max_lines_iter=20, max_outer_iter=100,
+            epsifac=0.9, epsired=0.1, cCoef=1000):
+    """
+    This function ipsolver solves the approximate problem P:
 
-    def subsolv(self, subprob, **kwargs):
-        """
-        This function subsolv solves the approximate subproblem P_NLP_tilde:
+    minimize
 
-        minimize
+    .. math::
 
-        .. math::
+        \\sum \\tilde{g_0} + a_0*z + \\sum \\left(c_i*y_i + 0.5*d_i*(y_i)^2\\right)
 
-            \\sum \\tilde{g_0} + a_0*z + \\sum \\left(c_i*y_i + 0.5*d_i*(y_i)^2\\right)
+    subject to
 
-        subject to
+    .. math::
 
-        .. math::
+        \\sum \\tilde{g_i} - a_i*z - y_i \\leq b_i \\\\
+        \\alpha_j \\leq  x_j \\leq  \\beta_j \\\\
+        y_i \\geq 0 \\\\
+        z \\geq 0
 
-            \\sum \\tilde{g_i} - a_i*z - y_i \\leq b_i \\\\
-            \\alpha_j \\leq  x_j \\leq  \\beta_j \\\\
-            y_i \\geq 0 \\\\
-            z \\geq 0
+    Input:  problem
+    Output: x, y, z, lam, xsi, eta, mu, zet, s
+    """
 
-        Input:  subprob
-        Output: x, y, z, lam, xsi, eta, mu, zet, s
-        """
+    # Initialization of parameters (once per design iteration)
+    n, m = problem.n, problem.m
+    a0 = 1.0
+    a = np.zeros(m)
+    c = cCoef * np.ones(m)
+    d = np.zeros(m)
+    epsi = 1
+    if x0 is None:
+        x = 0.5 * (problem.x_min + problem.x_max)
+    else:
+        x = x0.copy()
+    y = np.ones(m)
+    z = 1
+    lam = np.ones(m)
+    xsi = np.maximum((1.0 / (x - problem.x_min)), 1)
+    eta = np.maximum((1.0 / (problem.x_max - x)), 1)
+    mu = np.maximum(1, 0.5 * c)
+    zet = 1
+    s = np.ones(m)
+    outer_iter = 0
 
+    # Outer iterations that aim to solve the relaxed KKT conditions
+    while outer_iter < max_outer_iter and epsi > epsimin:
+        outer_iter += 1
 
-        # Initialization of parameters (once per design iteration)
-        a0 = 1.0
-        a = np.zeros(self.m)
-        c = self.cCoef * np.ones(self.m)
-        d = np.zeros(self.m)  # self.d = np.ones((self.m + 1, 1))
-        epsi = 1
-        x = 0.5 * (subprob.x_min + subprob.x_max)
-        y = np.ones(self.m)
-        z = 1
-        lam = np.ones(self.m)
-        xsi = np.maximum((1.0 / (x - subprob.x_min)), 1)
-        eta = np.maximum((1.0 / (subprob.x_max - x)), 1)
-        mu = np.maximum(1, 0.5 * c)
-        zet = 1
-        s = np.ones(self.m)
-        itera = 0
-        ittt = 0
+        # upcoming lines determine the left hand sides, i.e. the resiudals of all constraints
+        residunorm, residu = residual(x, y, z, lam, xsi, eta, mu, zet, s, epsi, a0, a, c, d, problem)
+        residumax = np.max(np.abs(residu))
 
+        # Newton step (Section 7.3)
+        # the algorithm is terminated when the maximum residual has become smaller than epsifac * epsi
+        # and epsi has become sufficiently small
+        inner_iter = 0
+        while inner_iter < max_inner_iter and residumax > epsifac * epsi:
+            inner_iter = inner_iter + 1
 
-        while epsi > self.epsimin:
-            self.counter += 1
+            # Calculating PSIjj
+            g_j_tilde_value = problem.g(x)
+            dg_j_tilde_value = problem.dg(x)
+            dg_j_tilde2_value = problem.ddg(x)
+            dpsi_dx = (dg_j_tilde_value[0, :] + np.dot(lam, dg_j_tilde_value[1:, :]))
+            d2psi_dx2 = (dg_j_tilde2_value[0, :] + np.dot(lam, dg_j_tilde2_value[1:, :]))
 
-            # print("iter: %2d" % self.counter, ", ",
-            #       "solves: %2d" % ittt, ", ",
-            #       "obj: %.2e" % subprob.g(x)[0], ", ",
-            #       "x:", ["{:+.2f}".format(i) for i in x[1:3]], ", ",
-            #       "lam:", ["{:+.2f}".format(i) for i in lam])
+            # Calculation of right hand sides of partially reduced system (Svanberg1998/page 16)
+            delx = dpsi_dx - epsi / (x - problem.x_min) + epsi / (problem.x_max - x)
+            dely = c + d * y - lam - epsi / y
+            delz = a0 - np.dot(a, lam) - epsi / z
+            dellam = g_j_tilde_value[1:] - a * z - y + epsi / lam
 
-            # upcoming lines determine the left hand sides, i.e. the resiudals of all constraints
-            residunorm, residu = self.residual(x, y, z, lam, xsi, eta, mu, zet, s, epsi, a0, a, c, d, subprob)
+            # Calculation of diagonal matrices: Dx, Dy, Dlam
+            diagx = d2psi_dx2 + xsi/(x - problem.x_min) + eta/(problem.x_max - x)
+            diagy = d + mu / y
+            diaglam = s / lam                           # - is missing
+            diaglamyi = diaglam + 1.0 / diagy           # what is that?
+
+            # form reduced system of Eq(7.9)
+            blam = dellam + dely / diagy - np.dot(dg_j_tilde_value[1:, :], (delx / diagx))
+            bb = np.hstack((blam, delz))
+            Alam = np.diag(diaglamyi) + np.einsum('ij,j,kj->ik', dg_j_tilde_value[1:, :], (1 / diagx),
+                                                  dg_j_tilde_value[1:, :])
+            AA = np.hstack((np.vstack((Alam, a.T)), np.array([np.hstack((a, -zet / z))]).T))
+
+            # solve system for delta lambda and delta z
+            solut = np.linalg.solve(AA, bb)
+
+            # solution of delta vars
+            dlam = solut[0:m]
+            dz = solut[m]
+            dx = -delx / diagx - np.dot(dg_j_tilde_value[1:, :].T, dlam) / diagx
+            dy = -dely / diagy + dlam / diagy
+            dxsi = -xsi + epsi / (x - problem.x_min) - (xsi * dx) / (x - problem.x_min)
+            deta = -eta + epsi / (problem.x_max - x) + (eta * dx) / (problem.x_max - x)
+            dmu = -mu + epsi / y - (mu * dy) / y
+            dzet = -zet + epsi / z - zet * dz / z
+            ds = -s + epsi / lam - (s * dlam) / lam
+
+            # Form inequalities of page 17 (theta = steg). Inequalities become equalities cuz we want max{theta}
+            xx = np.hstack((y, z, lam, xsi, eta, mu, zet, s))
+            dxx = np.hstack((dy, dz, dlam, dxsi, deta, dmu, dzet, ds))
+
+            # calculate the step-size
+            stepxx = -1.01 * dxx / xx
+            stmxx = np.max(stepxx)
+
+            stepalpha = -1.01 * dx / (x - problem.x_min)
+            stmalpha = np.max(stepalpha)
+
+            stepbeta = 1.01 * dx / (problem.x_max - x)
+            stmbeta = np.max(stepbeta)
+
+            # Step-size calculation: We 're looking for the max{theta} that satisfies the above equalities
+            steg = 1.0 / np.maximum.reduce([stmalpha, stmbeta, stmxx, 1])
+
+            # set old variables
+            xold = x.copy()
+            yold = y.copy()
+            zold = z
+            lamold = lam.copy()
+            xsiold = xsi.copy()
+            etaold = eta.copy()
+            muold = mu.copy()
+            zetold = zet
+            sold = s.copy()
+
+            # why put net residual twice the initial norm?
+            resinew = 2 * residunorm
+
+            # Line search to find the optimal step-size
+            lines_iter = 0
+            while lines_iter < max_lines_iter and resinew > residunorm:
+                lines_iter = lines_iter + 1
+
+                # Calculate new point in the line-search
+                x = xold + steg * dx
+                y = yold + steg * dy
+                z = zold + steg * dz
+                lam = lamold + steg * dlam
+                xsi = xsiold + steg * dxsi
+                eta = etaold + steg * deta
+                mu = muold + steg * dmu
+                zet = zetold + steg * dzet
+                s = sold + steg * ds
+
+                # Recalculate residual of equations
+                resinew, residu = residual(x, y, z, lam, xsi, eta, mu, zet, s, epsi, a0, a, c, d, problem)
+
+                # Reduce step-size by 50%
+                steg *= 0.5
+
+            residunorm = resinew
             residumax = np.max(np.abs(residu))
 
-            # Newton step (Section 7.3)
-            # the algorithm is terminated when the maximum residual has become smaller than 0.9*epsi
-            # and epsi has become sufficiently small
-            ittt = 0
-            while (residumax > 0.9 * epsi) and (ittt < self.maxittt):
-                ittt = ittt + 1
-                itera = itera + 1
+            # Double the step-size
+            steg *= 2
 
-                # Calculating PSIjj
-                g_j_tilde_value = subprob.g(x)
-                dg_j_tilde_value = subprob.dg(x)
-                dg_j_tilde2_value = subprob.ddg(x)
-                dpsi_dx = (dg_j_tilde_value[0, :] + np.dot(lam, dg_j_tilde_value[1:, :]))
-                d2psi_dx2 = (dg_j_tilde2_value[0, :] + np.dot(lam, dg_j_tilde2_value[1:, :]))
+        # Reduce epsilon with factor epsired
+        epsi *= epsired
 
-                # Calculation of right hand sides of partially reduced system (Svanberg1998/page 16)
-                delx = dpsi_dx - epsi / (x - subprob.x_min) + epsi / (subprob.x_max - x)
-                dely = c + d * y - lam - epsi / y
-                delz = a0 - np.dot(a, lam) - epsi / z
-                dellam = g_j_tilde_value[1:] - a * z - y + epsi / lam
+    return x
 
-                # Calculation of diagonal matrices: Dx, Dy, Dlam
-                diagx = d2psi_dx2 + xsi/(x - subprob.x_min) + eta/(subprob.x_max - x)
-                diagy = d + mu / y
-                diaglam = s / lam                           # - is missing
-                diaglamyi = diaglam + 1.0 / diagy           # what is that?
 
-                # form reduced system of Eq(7.9)
-                blam = dellam + dely / diagy - np.dot(dg_j_tilde_value[1:, :], (delx / diagx))
-                bb = np.hstack((blam, delz))
-                Alam = np.diag(diaglamyi) + np.einsum('ij,j,kj->ik', dg_j_tilde_value[1:, :], (1 / diagx),
-                                                      dg_j_tilde_value[1:, :])
-                AA = np.hstack((np.vstack((Alam, a.T)), np.array([np.hstack((a, -zet / z))]).T))
+## Calculates the residual of the relaxed KKT conditions
+def residual(x, y, z, lam, xsi, eta, mu, zet, s, epsi, a0, a, c, d, problem):
 
-                # solve system for delta lambda and delta z
-                solut = np.linalg.solve(AA, bb)
+    # Calculating g_j_tilde_value, dg_j_tilde_value and dpsi_dx
+    g_j_tilde_value = problem.g(x)
+    dg_j_tilde_value = problem.dg(x)
+    dpsi_dx = (dg_j_tilde_value[0, :] + np.dot(lam.T, dg_j_tilde_value[1:, :]))
 
-                # solution of delta vars
-                dlam = solut[0:self.m]
-                dz = solut[self.m]
-                dx = -delx / diagx - np.dot(dg_j_tilde_value[1:, :].T, dlam) / diagx
-                dy = -dely / diagy + dlam / diagy
-                dxsi = -xsi + epsi / (x - subprob.x_min) - (xsi * dx) / (x - subprob.x_min)
-                deta = -eta + epsi / (subprob.x_max - x) + (eta * dx) / (subprob.x_max - x)
-                dmu = -mu + epsi / y - (mu * dy) / y
-                dzet = -zet + epsi / z - zet * dz / z
-                ds = -s + epsi / lam - (s * dlam) / lam
+    # Calculation of other residuals
+    rex = dpsi_dx - xsi + eta
+    rey = c + d * y - mu - lam
+    rez = a0 - zet - np.dot(a, lam)
+    relam = g_j_tilde_value[1:] - a * z - y + s
+    rexsi = xsi * (x - problem.x_min) - epsi
+    reeta = eta * (problem.x_max - x) - epsi
+    remu = mu * y - epsi
+    rezet = zet * z - epsi
+    res = lam * s - epsi
 
-                # Form inequalities of page 17 (theta = steg). Inequalities become equalities cuz we want max{theta}
-                xx = np.hstack((y, z, lam, xsi, eta, mu, zet, s))
-                dxx = np.hstack((dy, dz, dlam, dxsi, deta, dmu, dzet, ds))
+    # Put all residuals in one line
+    residu = np.hstack((rex, rexsi, reeta, relam, res, rey, remu, rez, rezet))
 
-                # calculate the step-size
-                stepxx = -1.01 * dxx / xx
-                stmxx = np.max(stepxx)
-
-                stepalpha = -1.01 * dx / (x - subprob.x_min)
-                stmalpha = np.max(stepalpha)
-
-                stepbeta = 1.01 * dx / (subprob.x_max - x)
-                stmbeta = np.max(stepbeta)
-
-                # Step-size calculation: We 're looking for the max{theta} that satisfies the above equalities
-                steg = 1.0 / np.maximum.reduce([stmalpha, stmbeta, stmxx, 1])
-
-                # set old variables
-                xold = x.copy()
-                yold = y.copy()
-                zold = z
-                lamold = lam.copy()
-                xsiold = xsi.copy()
-                etaold = eta.copy()
-                muold = mu.copy()
-                zetold = zet
-                sold = s.copy()
-
-                # why put net residual twice the initial norm?
-                resinew = 2 * residunorm
-
-                # Line search to find the optimal step-size
-                itto = 0
-                while (resinew > residunorm) and (itto < self.maxittt):
-                    itto = itto + 1
-
-                    # Calculate new point in the line-search
-                    x = xold + steg * dx
-                    y = yold + steg * dy
-                    z = zold + steg * dz
-                    lam = lamold + steg * dlam
-                    xsi = xsiold + steg * dxsi
-                    eta = etaold + steg * deta
-                    mu = muold + steg * dmu
-                    zet = zetold + steg * dzet
-                    s = sold + steg * ds
-
-                    # Recalculate residual of equations
-                    resinew, residu = self.residual(x, y, z, lam, xsi, eta, mu, zet, s, epsi, a0, a, c, d, subprob)
-
-                    # Reduce step-size by 50%
-                    steg *= 0.5
-
-                residunorm = resinew
-                residumax = np.max(np.abs(residu))
-
-                # Double the step-size
-                steg *= 2
-
-            # Decrease epsilon with factor 10
-            epsi *= 0.1
-
-        # print(itera)
-        return x, y, z, lam, xsi, eta, mu, zet, s
-
-    ## Calculates the residual of the relaxed KKT conditions
-    @staticmethod
-    def residual(x, y, z, lam, xsi, eta, mu, zet, s, epsi, a0, a, c, d, subprob):
-
-        # Calculating g_j_tilde_value, dg_j_tilde_value and dpsi_dx
-        g_j_tilde_value = subprob.g(x)
-        dg_j_tilde_value = subprob.dg(x)
-        dpsi_dx = (dg_j_tilde_value[0, :] + np.dot(lam.T, dg_j_tilde_value[1:, :]))
-
-        # Calculation of other residuals
-        rex = dpsi_dx - xsi + eta
-        rey = c + d * y - mu - lam
-        rez = a0 - zet - np.dot(a, lam)
-        relam = g_j_tilde_value[1:] - a * z - y + s
-        rexsi = xsi * (x - subprob.x_min) - epsi
-        reeta = eta * (subprob.x_max - x) - epsi
-        remu = mu * y - epsi
-        rezet = zet * z - epsi
-        res = lam * s - epsi
-
-        # Put all residuals in one line
-        # residu = np.hstack((rex, rey, rez, relam, rexsi, reeta, remu, rezet, res))
-        residu = np.hstack((rex, rexsi, reeta, relam, res, rey, remu, rez, rezet))
-
-        # Euclidean norm calculation
-        # resinew = np.sqrt(np.dot(residu.T, residu))
-        resinew = np.linalg.norm(residu)
-        return resinew, residu
+    # Euclidean norm calculation
+    resinew = np.linalg.norm(residu)
+    return resinew, residu

--- a/sao/solvers/__init__.py
+++ b/sao/solvers/__init__.py
@@ -3,3 +3,4 @@ from sao.solvers.optimality_criteria import oc, oc1999
 from sao.solvers.SolverIP_Svanberg import SvanbergIP
 from sao.solvers.method_of_moving_asymptotes import mma
 from sao.solvers.cvxopt_wrapper import CVXOPT
+from sao.solvers.scipy_wrapper import SCIPY

--- a/sao/solvers/__init__.py
+++ b/sao/solvers/__init__.py
@@ -2,5 +2,5 @@ from sao.solvers.primal_dual_interior_point import pdip
 from sao.solvers.optimality_criteria import oc, oc1999
 from sao.solvers.SolverIP_Svanberg import ipsolver
 from sao.solvers.method_of_moving_asymptotes import mma
-from sao.solvers.cvxopt_wrapper import CVXOPT
+from sao.solvers.cvxopt_wrapper import cvxopt_solver
 from sao.solvers.scipy_wrapper import scipy_solver

--- a/sao/solvers/__init__.py
+++ b/sao/solvers/__init__.py
@@ -1,6 +1,6 @@
 from sao.solvers.primal_dual_interior_point import pdip
 from sao.solvers.optimality_criteria import oc, oc1999
-from sao.solvers.SolverIP_Svanberg import SvanbergIP
+from sao.solvers.SolverIP_Svanberg import ipsolver
 from sao.solvers.method_of_moving_asymptotes import mma
 from sao.solvers.cvxopt_wrapper import CVXOPT
-from sao.solvers.scipy_wrapper import SCIPY
+from sao.solvers.scipy_wrapper import scipy_solver

--- a/sao/solvers/cvxopt_wrapper.py
+++ b/sao/solvers/cvxopt_wrapper.py
@@ -1,50 +1,39 @@
 ## Imports
 import numpy as np
-from cvxopt import solvers, matrix, spdiag
+
+try:
+    from cvxopt import solvers, matrix, spdiag
+except ImportError:
+    raise Exception(
+        "Package cvxopt is not available in the current environment. "
+        "Install cvxopt or install SAOR with feature flags cvxopt.")
 
 
-class CVXOPT:
+def cvxopt_solver(problem, **kwargs):
     """
-    This is a wrapper class to use the CVXOPT solver library found in the following link:
+    This is a wrapper function that uses the ``cvxopt`` solver library found in the following link:
     https://cvxopt.org/userguide/solvers.html#problems-with-nonlinear-objectives
+
+    minimize
+
+    .. math::
+
+        \\tilde{g}_0^{(k)}[mathbf{x}]
+
+    subject to
+
+    .. math::
+
+        \\tilde{g}_j^{(k)}[mathbf{x}] \\leq 0  ,  j = 1, ..., m \\\\
+        \\x_min_i^{(k)} \\leq  x_i \\leq  \\x_max_i^{(k)}  ,  i = 1, ..., n \\\\
+
+    Input:  subprob
+    Output: x
     """
-    def __init__(self, n, m):
-        self.n = n
-        self.m = m
-        self.subprob = None
 
-    def subsolv(self, subprob, **kwargs):
+    def F(x=None, z=None):
         """
-                This method solves the approximate subproblem P_NLP_tilde:
-
-                minimize
-
-                .. math::
-
-                    \\tilde{g}_0^{(k)}[mathbf{x}]
-
-                subject to
-
-                .. math::
-
-                    \\tilde{g}_j^{(k)}[mathbf{x}] \\leq 0  ,  j = 1, ..., m \\\\
-                    \\x_min_i^{(k)} \\leq  x_i \\leq  \\x_max_i^{(k)}  ,  i = 1, ..., n \\\\
-
-                Input:  subprob
-                Output: x
-                """
-
-        self.subprob = subprob
-
-        # Linear inequality constraints (problem bounds)
-        G = matrix(np.append(np.eye(self.n), -np.eye(self.n), axis=0))
-        h = matrix(np.append(self.subprob.x_max, -self.subprob.x_min), (2*self.n, 1))
-
-        return solvers.cp(self.F, G, h)['x']
-
-    def F(self, x=None, z=None):
-        """
-        This function is required by the CVXOPT library, see https://cvxopt.org/userguide/solvers.html#s-cp.
+        This function is required by the ``cvxopt`` library, see https://cvxopt.org/userguide/solvers.html#s-cp.
 
         :param x:
         :param z:
@@ -52,12 +41,18 @@ class CVXOPT:
         """
 
         if x is None:
-            x0 = matrix(0.5*(self.subprob.x_min+self.subprob.x_max), (self.n, 1))
-            return self.m, x0
-        f = matrix(self.subprob.g(np.array(x).flatten()), (self.m+1, 1))
-        Df = matrix(self.subprob.dg(np.array(x).flatten()), (self.m+1, self.n))
+            x0 = matrix(0.5 * (problem.x_min + problem.x_max), (problem.n, 1))
+            return problem.m, x0
+        f = matrix(problem.g(np.array(x).flatten()), (problem.m + 1, 1))
+        Df = matrix(problem.dg(np.array(x).flatten()), (problem.m + 1, problem.n))
         if z is None:
             return f, Df
-        DiagonalHessian = matrix(self.subprob.ddg(np.array(x).flatten()))
+        DiagonalHessian = matrix(problem.ddg(np.array(x).flatten()))
         H = spdiag(DiagonalHessian.T * z)
         return f, Df, H
+
+    # Linear inequality constraints (problem bounds)
+    G = matrix(np.append(np.eye(problem.n), -np.eye(problem.n), axis=0))
+    h = matrix(np.append(problem.x_max, -problem.x_min), (2*problem.n, 1))
+
+    return solvers.cp(F, G, h)['x']

--- a/sao/solvers/scipy_wrapper.py
+++ b/sao/solvers/scipy_wrapper.py
@@ -1,0 +1,62 @@
+## Imports
+from scipy import optimize
+
+
+class SCIPY:
+    """
+    This is a wrapper class to use the SCIPY optimization library found in the following link:
+    https://docs.scipy.org/doc/scipy/tutorial/optimize.html#constrained-minimization-of-multivariate-scalar-functions-minimize.
+    Requires an installation of ``scipy``.
+    """
+    def __init__(self, n, m, **kwargs):
+        self.n = n
+        self.m = m
+        self.subprob = None
+
+    def subsolv(self, subprob, **kwargs):
+        """
+                This method solves the approximate subproblem P_NLP_tilde:
+
+                minimize
+
+                .. math::
+
+                    \\tilde{g}_0^{(k)}[mathbf{x}]
+
+                subject to
+
+                .. math::
+
+                    \\tilde{g}_j^{(k)}[mathbf{x}] \\leq 0  ,  j = 1, ..., m \\\\
+                    \\x_min_i^{(k)} \\leq  x_i \\leq  \\x_max_i^{(k)}  ,  i = 1, ..., n \\\\
+
+                Input:  subprob
+                Output: x
+                """
+
+        self.subprob = subprob
+        x0 = kwargs.get('x0', 0.5*(self.subprob.x_min + self.subprob.x_max))
+        bounds = optimize.Bounds(subprob.x_min, subprob.x_max)
+        # ineq_cons = optimize.NonlinearConstraint(self.constraints, -np.inf, 0, jac=self.constraints_der)
+        ineq_cons = {'type': 'ineq',
+                     'fun' : self.constraints,
+                     'jac' : self.constraints_der}
+        solution = optimize.minimize(self.objective, x0, bounds=bounds, method='trust-constr',
+                                     jac=self.objective_der, constraints=ineq_cons, options={'gtol': 1e-6})
+        return solution.x
+
+    def objective(self, x):
+        return self.subprob.g(x)[0]
+
+    def objective_der(self, x):
+        return self.subprob.dg(x)[0]
+
+    def constraints(self, x):
+        """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
+        return -self.subprob.g(x)[1:]
+
+    def constraints_der(self, x):
+        """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
+        return -self.subprob.dg(x)[1:]
+
+    # TODO: Possibly add diagonal Hessian that we currently have (they use a full Hessian with different dimensions)

--- a/sao/solvers/scipy_wrapper.py
+++ b/sao/solvers/scipy_wrapper.py
@@ -43,6 +43,8 @@ def scipy_solver(problem, **kwargs):
                  }
     method = kwargs.get('method', 'SLSQP')
     options = kwargs.get('options', None)
-    solution = optimize.minimize(objective, x0, bounds=bounds, method=method,
-                                 jac=objective_der, constraints=ineq_cons, options=options)
+
+    # https://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.minimize.html#scipy.optimize.minimize
+    solution = optimize.minimize(objective, x0, bounds=bounds, method=method, jac=objective_der,
+                                 constraints=ineq_cons, options=options)
     return solution.x

--- a/sao/solvers/scipy_wrapper.py
+++ b/sao/solvers/scipy_wrapper.py
@@ -41,8 +41,8 @@ class SCIPY:
         ineq_cons = {'type': 'ineq',
                      'fun' : self.constraints,
                      'jac' : self.constraints_der}
-        solution = optimize.minimize(self.objective, x0, bounds=bounds, method='trust-constr',
-                                     jac=self.objective_der, constraints=ineq_cons, options={'gtol': 1e-6})
+        solution = optimize.minimize(self.objective, x0, bounds=bounds, method='SLSQP',
+                                     jac=self.objective_der, constraints=ineq_cons, options={'ftol': 1e-8})
         return solution.x
 
     def objective(self, x):

--- a/sao/solvers/scipy_wrapper.py
+++ b/sao/solvers/scipy_wrapper.py
@@ -1,64 +1,65 @@
 ## Imports
 from scipy import optimize
 
+"""
+This is a wrapper class to use the SCIPY optimization library found in the following link:
+https://docs.scipy.org/doc/scipy/tutorial/optimize.html#constrained-minimization-of-multivariate-scalar-functions-minimize.
+Requires an installation of ``scipy``.
+"""
 
-class SCIPY:
-    """
-    This is a wrapper class to use the SCIPY optimization library found in the following link:
-    https://docs.scipy.org/doc/scipy/tutorial/optimize.html#constrained-minimization-of-multivariate-scalar-functions-minimize.
-    Requires an installation of ``scipy``.
-    """
-    def __init__(self, n, m, **kwargs):
-        self.n = n
-        self.m = m
-        self.subprob = None
 
-    def subsolv(self, subprob, **kwargs):
+def scipy_solver(problem, **kwargs):
+    """
+        This method solves the approximate problem P:
+
+        minimize
+
+        .. math::
+
+            \\tilde{g}_0^{(k)}[mathbf{x}]
+
+        subject to
+
+        .. math::
+
+            \\tilde{g}_j^{(k)}[mathbf{x}] \\leq 0  ,  j = 1, ..., m \\\\
+            \\x_min_i^{(k)} \\leq  x_i \\leq  \\x_max_i^{(k)}  ,  i = 1, ..., n \\\\
+
+        Input:  problem
+        Output: x
         """
-                This method solves the approximate subproblem P_NLP_tilde:
 
-                minimize
+    problem = problem
+    x0 = kwargs.get('x0', 0.5*(problem.x_min + problem.x_max))
+    bounds = optimize.Bounds(problem.x_min, problem.x_max)
+    # ineq_cons = optimize.NonlinearConstraint(constraints, -np.inf, 0, jac=constraints_der)
+    ineq_cons = {'type': 'ineq',
+                 'fun' : constraints,
+                 'jac' : constraints_der,
+                 'args': (problem.g, problem.dg)}
+    method = kwargs.get('method', 'SLSQP')
+    options = kwargs.get('options', None)
+    solution = optimize.minimize(objective, x0, args=(problem.g, problem.dg), bounds=bounds, method=method,
+                                 jac=objective_der, constraints=ineq_cons, options=options)
+    return solution.x
 
-                .. math::
 
-                    \\tilde{g}_0^{(k)}[mathbf{x}]
+def objective(x, *args):
+    return args[0](x)[0]
 
-                subject to
 
-                .. math::
+def objective_der(x, *args):
+    return args[1](x)[0]
 
-                    \\tilde{g}_j^{(k)}[mathbf{x}] \\leq 0  ,  j = 1, ..., m \\\\
-                    \\x_min_i^{(k)} \\leq  x_i \\leq  \\x_max_i^{(k)}  ,  i = 1, ..., n \\\\
 
-                Input:  subprob
-                Output: x
-                """
+def constraints(x, *args):
+    """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
+    return -args[0](x)[1:]
 
-        self.subprob = subprob
-        x0 = kwargs.get('x0', 0.5*(self.subprob.x_min + self.subprob.x_max))
-        bounds = optimize.Bounds(subprob.x_min, subprob.x_max)
-        # ineq_cons = optimize.NonlinearConstraint(self.constraints, -np.inf, 0, jac=self.constraints_der)
-        ineq_cons = {'type': 'ineq',
-                     'fun' : self.constraints,
-                     'jac' : self.constraints_der}
-        method = kwargs.get('method', 'SLSQP')
-        options = kwargs.get('options', None)
-        solution = optimize.minimize(self.objective, x0, bounds=bounds, method=method,
-                                     jac=self.objective_der, constraints=ineq_cons, options=options)
-        return solution.x
 
-    def objective(self, x):
-        return self.subprob.g(x)[0]
+def constraints_der(x, *args):
+    """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
+    return -args[1](x)[1:]
 
-    def objective_der(self, x):
-        return self.subprob.dg(x)[0]
 
-    def constraints(self, x):
-        """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
-        return -self.subprob.g(x)[1:]
-
-    def constraints_der(self, x):
-        """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
-        return -self.subprob.dg(x)[1:]
-
-    # TODO: Possibly add diagonal Hessian that we currently have (they use a full Hessian with different dimensions)
+# TODO: Possibly add diagonal Hessian that we currently have (they use a full Hessian with different dimensions)

--- a/sao/solvers/scipy_wrapper.py
+++ b/sao/solvers/scipy_wrapper.py
@@ -29,35 +29,20 @@ def scipy_solver(problem, **kwargs):
         Output: x
         """
 
-    def objective(x, *args):
-        problem, *_ = args
-        return problem.g(x)[0]
-
-    def objective_der(x, *args):
-        problem, *_ = args
-        return problem.dg(x)[0]
-
-    def constraints(x, *args):
-        """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
-        problem, *_ = args
-        return -problem.g(x)[1:]
-
-    def constraints_der(x, *args):
-        """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
-        problem, *_ = args
-        return -problem.dg(x)[1:]
-
-    # TODO: Possibly add diagonal Hessian that we currently have (they use a full Hessian with different dimensions)
-
     x0 = kwargs.get('x0', 0.5*(problem.x_min + problem.x_max))
     bounds = optimize.Bounds(problem.x_min, problem.x_max)
-    # ineq_cons = optimize.NonlinearConstraint(constraints, -np.inf, 0, jac=constraints_der)
+    objective = lambda x: problem.g(x)[0]
+    objective_der = lambda x: problem.dg(x)[0]
+    constraints = lambda x: -problem.g(x)[1:]
+    constraints_der = lambda x: -problem.dg(x)[1:]
+    # TODO: Possibly add diagonal Hessian that we currently have (they use a full Hessian with different dimensions)
+
     ineq_cons = {'type': 'ineq',
-                 'fun' : constraints,
-                 'jac' : constraints_der,
-                 'args': (problem, Ellipsis)}
+                 'fun': constraints,
+                 'jac': constraints_der,
+                 }
     method = kwargs.get('method', 'SLSQP')
     options = kwargs.get('options', None)
-    solution = optimize.minimize(objective, x0, args=(problem, Ellipsis), bounds=bounds, method=method,
+    solution = optimize.minimize(objective, x0, bounds=bounds, method=method,
                                  jac=objective_der, constraints=ineq_cons, options=options)
     return solution.x

--- a/sao/solvers/scipy_wrapper.py
+++ b/sao/solvers/scipy_wrapper.py
@@ -41,8 +41,10 @@ class SCIPY:
         ineq_cons = {'type': 'ineq',
                      'fun' : self.constraints,
                      'jac' : self.constraints_der}
-        solution = optimize.minimize(self.objective, x0, bounds=bounds, method='SLSQP',
-                                     jac=self.objective_der, constraints=ineq_cons, options={'ftol': 1e-8})
+        method = kwargs.get('method', 'SLSQP')
+        options = kwargs.get('options', None)
+        solution = optimize.minimize(self.objective, x0, bounds=bounds, method=method,
+                                     jac=self.objective_der, constraints=ineq_cons, options=options)
         return solution.x
 
     def objective(self, x):

--- a/sao/solvers/scipy_wrapper.py
+++ b/sao/solvers/scipy_wrapper.py
@@ -10,7 +10,7 @@ Requires an installation of ``scipy``.
 
 def scipy_solver(problem, **kwargs):
     """
-        This method solves the approximate problem P:
+        This function solves a given problem P:
 
         minimize
 
@@ -29,7 +29,26 @@ def scipy_solver(problem, **kwargs):
         Output: x
         """
 
-    problem = problem
+    def objective(x, *args):
+        problem, *_ = args
+        return problem.g(x)[0]
+
+    def objective_der(x, *args):
+        problem, *_ = args
+        return problem.dg(x)[0]
+
+    def constraints(x, *args):
+        """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
+        problem, *_ = args
+        return -problem.g(x)[1:]
+
+    def constraints_der(x, *args):
+        """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
+        problem, *_ = args
+        return -problem.dg(x)[1:]
+
+    # TODO: Possibly add diagonal Hessian that we currently have (they use a full Hessian with different dimensions)
+
     x0 = kwargs.get('x0', 0.5*(problem.x_min + problem.x_max))
     bounds = optimize.Bounds(problem.x_min, problem.x_max)
     # ineq_cons = optimize.NonlinearConstraint(constraints, -np.inf, 0, jac=constraints_der)
@@ -42,28 +61,3 @@ def scipy_solver(problem, **kwargs):
     solution = optimize.minimize(objective, x0, args=(problem, Ellipsis), bounds=bounds, method=method,
                                  jac=objective_der, constraints=ineq_cons, options=options)
     return solution.x
-
-
-def objective(x, *args):
-    problem, *_ = args
-    return problem.g(x)[0]
-
-
-def objective_der(x, *args):
-    problem, *_ = args
-    return problem.dg(x)[0]
-
-
-def constraints(x, *args):
-    """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
-    problem, *_ = args
-    return -problem.g(x)[1:]
-
-
-def constraints_der(x, *args):
-    """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
-    problem, *_ = args
-    return -problem.dg(x)[1:]
-
-
-# TODO: Possibly add diagonal Hessian that we currently have (they use a full Hessian with different dimensions)

--- a/sao/solvers/scipy_wrapper.py
+++ b/sao/solvers/scipy_wrapper.py
@@ -36,30 +36,34 @@ def scipy_solver(problem, **kwargs):
     ineq_cons = {'type': 'ineq',
                  'fun' : constraints,
                  'jac' : constraints_der,
-                 'args': (problem.g, problem.dg)}
+                 'args': (problem, Ellipsis)}
     method = kwargs.get('method', 'SLSQP')
     options = kwargs.get('options', None)
-    solution = optimize.minimize(objective, x0, args=(problem.g, problem.dg), bounds=bounds, method=method,
+    solution = optimize.minimize(objective, x0, args=(problem, Ellipsis), bounds=bounds, method=method,
                                  jac=objective_der, constraints=ineq_cons, options=options)
     return solution.x
 
 
 def objective(x, *args):
-    return args[0](x)[0]
+    problem, *_ = args
+    return problem.g(x)[0]
 
 
 def objective_der(x, *args):
-    return args[1](x)[0]
+    problem, *_ = args
+    return problem.dg(x)[0]
 
 
 def constraints(x, *args):
     """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
-    return -args[0](x)[1:]
+    problem, *_ = args
+    return -problem.g(x)[1:]
 
 
 def constraints_der(x, *args):
     """ The minus sign is there because inequality constraints must be in the form g_j >= 0."""
-    return -args[1](x)[1:]
+    problem, *_ = args
+    return -problem.dg(x)[1:]
 
 
 # TODO: Possibly add diagonal Hessian that we currently have (they use a full Hessian with different dimensions)

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ setup(
     install_requires=[
         'numpy',
         'scipy',
-        'cvxopt',
     ],
     extras_require={
         'all': _all,

--- a/tests/solvers/test_solvers.py
+++ b/tests/solvers/test_solvers.py
@@ -3,9 +3,9 @@ import numpy as np
 import logging
 from Problems._nd.Square import Square
 from sao.solvers.primal_dual_interior_point import pdip, Pdipx, Pdipxy, Pdipxyz
-from sao.solvers.SolverIP_Svanberg import SvanbergIP
+from sao.solvers.SolverIP_Svanberg import ipsolver
 from sao.solvers.cvxopt_wrapper import CVXOPT
-from sao.solvers.scipy_wrapper import SCIPY
+from sao.solvers.scipy_wrapper import scipy_solver
 
 # Set options for logging data: https://www.youtube.com/watch?v=jxmzY9soFXg&ab_channel=CoreySchafer
 logger = logging.getLogger(__name__)
@@ -40,8 +40,7 @@ def test_square(n):
     # Test sao.solvers.SolverIP_Svanberg.py
     logger.info("Solve x**2 using SvanbergIP")
     problem_svan = Square(n)
-    mysolver_svan = SvanbergIP(problem_svan.n, problem_svan.m)
-    x_opt_svan, y, z, lam, xsi, eta, mu, zet, s = mysolver_svan.subsolv(problem_svan)
+    x_opt_svan = ipsolver(problem_svan, epsimin=1e-7)
     assert np.sum(x_opt_svan) == pytest.approx(1, rel=1e-4)
 
     # Test sao.solvers.cvxopt_wrapper.py
@@ -54,8 +53,7 @@ def test_square(n):
     # Test sao.solvers.cvxopt_wrapper.py
     logger.info("Solve x**2 using scipy")
     problem_scipy = Square(n)
-    mysolver_scipy = SCIPY(problem_scipy.n, problem_scipy.m)
-    x_opt_scipy = mysolver_scipy.subsolv(problem_scipy)
+    x_opt_scipy = scipy_solver(problem_scipy)
     assert np.sum(x_opt_scipy) == pytest.approx(1, rel=1e-4)
 
     # Compare results of solvers

--- a/tests/solvers/test_solvers.py
+++ b/tests/solvers/test_solvers.py
@@ -5,6 +5,7 @@ from Problems._nd.Square import Square
 from sao.solvers.primal_dual_interior_point import pdip, Pdipx, Pdipxy, Pdipxyz
 from sao.solvers.SolverIP_Svanberg import SvanbergIP
 from sao.solvers.cvxopt_wrapper import CVXOPT
+from sao.solvers.scipy_wrapper import SCIPY
 
 # Set options for logging data: https://www.youtube.com/watch?v=jxmzY9soFXg&ab_channel=CoreySchafer
 logger = logging.getLogger(__name__)
@@ -28,7 +29,7 @@ def test_square(n):
 
     logger.info("Solve x**2 using ipopt with x, y")
     problem_xy = Square(n)
-    x_opt_xy = pdip(problem_xy, variables=Pdipxyz, epsimin=1e-7)
+    x_opt_xy = pdip(problem_xy, variables=Pdipxy, epsimin=1e-7)
     assert np.sum(x_opt_xy) == pytest.approx(1, rel=1e-4)
 
     logger.info("Solve x**2 using ipopt with x")
@@ -47,13 +48,21 @@ def test_square(n):
     logger.info("Solve x**2 using cvxopt")
     problem_cvxopt = Square(n)
     mysolver_cvxopt = CVXOPT(problem_cvxopt.n, problem_cvxopt.m)
-    x_opt_cvxopt = mysolver_cvxopt.subsolv(problem_svan)
+    x_opt_cvxopt = mysolver_cvxopt.subsolv(problem_cvxopt)
     assert np.sum(x_opt_cvxopt) == pytest.approx(1, rel=1e-4)
+
+    # Test sao.solvers.cvxopt_wrapper.py
+    logger.info("Solve x**2 using scipy")
+    problem_scipy = Square(n)
+    mysolver_scipy = SCIPY(problem_scipy.n, problem_scipy.m)
+    x_opt_scipy = mysolver_scipy.subsolv(problem_scipy)
+    assert np.sum(x_opt_scipy) == pytest.approx(1, rel=1e-4)
 
     # Compare results of solvers
     assert np.linalg.norm(x_opt_xyz - x_opt_xy) == pytest.approx(0, abs=1e-4)
     assert np.linalg.norm(x_opt_svan - x_opt_x) == pytest.approx(0, abs=1e-4)
     assert np.linalg.norm(x_opt_cvxopt - x_opt_svan) == pytest.approx(0, abs=1e-4)
+    assert np.linalg.norm(x_opt_scipy - x_opt_cvxopt) == pytest.approx(0, abs=1e-4)
 
 
 if __name__ == "__main__":

--- a/tests/solvers/test_solvers.py
+++ b/tests/solvers/test_solvers.py
@@ -4,7 +4,7 @@ import logging
 from Problems._nd.Square import Square
 from sao.solvers.primal_dual_interior_point import pdip, Pdipx, Pdipxy, Pdipxyz
 from sao.solvers.SolverIP_Svanberg import ipsolver
-from sao.solvers.cvxopt_wrapper import CVXOPT
+from sao.solvers.cvxopt_wrapper import cvxopt_solver
 from sao.solvers.scipy_wrapper import scipy_solver
 
 # Set options for logging data: https://www.youtube.com/watch?v=jxmzY9soFXg&ab_channel=CoreySchafer
@@ -46,8 +46,7 @@ def test_square(n):
     # Test sao.solvers.cvxopt_wrapper.py
     logger.info("Solve x**2 using cvxopt")
     problem_cvxopt = Square(n)
-    mysolver_cvxopt = CVXOPT(problem_cvxopt.n, problem_cvxopt.m)
-    x_opt_cvxopt = mysolver_cvxopt.subsolv(problem_cvxopt)
+    x_opt_cvxopt = cvxopt_solver(problem_cvxopt)
     assert np.sum(x_opt_cvxopt) == pytest.approx(1, rel=1e-4)
 
     # Test sao.solvers.cvxopt_wrapper.py

--- a/tests/solvers/test_solvers.py
+++ b/tests/solvers/test_solvers.py
@@ -49,7 +49,7 @@ def test_square(n):
     x_opt_cvxopt = cvxopt_solver(problem_cvxopt)
     assert np.sum(x_opt_cvxopt) == pytest.approx(1, rel=1e-4)
 
-    # Test sao.solvers.cvxopt_wrapper.py
+    # Test sao.solvers.scipy_wrapper.py
     logger.info("Solve x**2 using scipy")
     problem_scipy = Square(n)
     x_opt_scipy = scipy_solver(problem_scipy)


### PR DESCRIPTION
This PR includes a wrapper function for `scipy`.  Related link can be found below:
https://docs.scipy.org/doc/scipy/reference/tutorial/optimize.html#constrained-minimization-of-multivariate-scalar-functions-minimize
One thing I am not 100% sure about is why defining the inequality constraints as a `NonlinearConstraint` object (instead of a dictionary that is currently implemented) gives a warning but still works. Note that, according to the above link, one can define it both ways.
```python
ineq_cons = optimize.NonlinearConstraint(self.constraints, -np.inf, 0, jac=self.constraints_der)
solution = optimize.minimize(self.objective, x0, bounds=bounds, method='trust-constr',
                                     jac=self.objective_der, constraints=ineq_cons, options={'gtol': 1e-6})
```
