### PR TITLE
Collect mma options in dataclass

### DIFF
--- a/examples/mbb.py
+++ b/examples/mbb.py
@@ -2,7 +2,7 @@ import numpy as np
 import logging
 from sao.approximations import Taylor1, Taylor2, SphericalTaylor2, NonSphericalTaylor2
 from sao.problems import Problem, Subproblem
-from sao.intervening_variables import Linear, MMA, MMAsquared, MixedIntervening
+from sao.intervening_variables import Linear, MMA, MMAsquared, MMAOptions, MixedIntervening
 from sao.move_limits import Bounds, MoveLimit, AdaptiveMoveLimit
 from sao.convergence_criteria import ObjectiveChange, VariableChange, IterationCount, Feasibility
 from sao.scaling_strategies import InitialObjectiveScaling, InitialResponseScaling
@@ -43,7 +43,7 @@ def example_compliance(nelx=100, nely=50, volfrac=0.4, penal=3, rmin=3):
     assert prob.n == nelx * nely
 
     # Instantiate a non-mixed approximation scheme
-    subprob = Subproblem(approximation=Taylor1(intervening=MMA(prob.xmin, prob.xmax, asyincr=1.3, asydecr=0.7)),
+    subprob = Subproblem(approximation=Taylor1(intervening=MMA(prob.xmin, prob.xmax, options=MMAOptions(asyincr=1.3, asydecr=0.7))),
                          limits=[Bounds(prob.xmin, prob.xmax), MoveLimit(move_limit=0.1)])
 
     # Instantiate solver
@@ -163,7 +163,7 @@ def example_stress(nelx=100, nely=50, volfrac=0.4, penal=3, rmin=3, max_stress=1
     assert prob.n == nelx * nely
 
     # Instantiate a non-mixed approximation scheme
-    subprob = Subproblem(approximation=Taylor1(intervening=MMA(prob.xmin, prob.xmax, asyincr=1.3, asydecr=0.7)),
+    subprob = Subproblem(approximation=Taylor1(intervening=MMA(prob.xmin, prob.xmax, options=MMAOptions(asyincr=1.3, asydecr=0.7))),
                          limits=[Bounds(prob.xmin, prob.xmax), MoveLimit(move_limit=0.1)])
 
     # Instantiate solver
@@ -284,7 +284,7 @@ def example_eigenvalue(nelx=100, nely=50, volfrac=0.6, penal=3, rmin=3):
     assert prob.n == nelx * nely
 
     # Instantiate a non-mixed approximation scheme
-    subprob = Subproblem(approximation=Taylor1(intervening=MMA(prob.xmin, prob.xmax, asyincr=1.3, asydecr=0.7)),
+    subprob = Subproblem(approximation=Taylor1(intervening=MMA(prob.xmin, prob.xmax, options=MMAOptions(asyincr=1.3, asydecr=0.7))),
                          limits=[Bounds(prob.xmin, prob.xmax), MoveLimit(move_limit=0.1)])
 
     # Instantiate solver
@@ -344,7 +344,7 @@ def example_self_weight(nelx=100, nely=50, volfrac=0.1, penal=3, rmin=3, load=1.
     assert prob.n == nelx * nely
 
     # Instantiate a non-mixed approximation scheme
-    subprob = Subproblem(approximation=Taylor1(intervening=MMA(prob.xmin, prob.xmax, asyincr=1.3, asydecr=0.7)),
+    subprob = Subproblem(approximation=Taylor1(intervening=MMA(prob.xmin, prob.xmax, options=MMAOptions(asyincr=1.3, asydecr=0.7))),
                          limits=[Bounds(prob.xmin, prob.xmax), MoveLimit(move_limit=0.1)])
 
     # Instantiate solver
@@ -404,7 +404,7 @@ def example_thermomech(nelx=100, nely=50, volfrac=0.1, penal=3, rmin=3, load=1.0
     assert prob.n == nelx * nely
 
     # Instantiate a non-mixed approximation scheme
-    subprob = Subproblem(approximation=Taylor1(intervening=MMA(prob.xmin, prob.xmax, asyincr=1.3, asydecr=0.7)),
+    subprob = Subproblem(approximation=Taylor1(intervening=MMA(prob.xmin, prob.xmax, options=MMAOptions(asyincr=1.3, asydecr=0.7))),
                          limits=[Bounds(prob.xmin, prob.xmax), MoveLimit(move_limit=0.1)])
 
     # Instantiate solver

--- a/sao/intervening_variables/__init__.py
+++ b/sao/intervening_variables/__init__.py
@@ -3,10 +3,10 @@ from .exponential import Linear, Exponential
 from .exponential import Reciprocal, ReciSquared, ReciCubed
 from .conlin import ConLin
 from .fitted import ReciFit
-from .mma import MMA, MMAsquared, MMAcubed
+from .mma import MMA, MMAsquared, MMAcubed, MMAOptions
 from .mixed_intervening import MixedIntervening
 
 __all__ = [
         'Linear', 'ConLin', 'Exponential', 'Reciprocal', 'ReciSquared',
-        'ReciCubed', 'ReciFit', 'MMA', 'MMAsquared', 'MMAcubed', 'MixedIntervening'
+        'ReciCubed', 'ReciFit', 'MMA', 'MMAsquared', 'MMAcubed', 'MMAOptions', 'MixedIntervening'
 ]

--- a/sao/intervening_variables/mma.py
+++ b/sao/intervening_variables/mma.py
@@ -5,6 +5,16 @@ from .intervening import Intervening
 
 @dataclass
 class MMAOptions():
+    """Options for the MMA-algorithms and their default values.
+
+    Attributes:
+        asyinit (float): Initial values for the asymptotes.
+        asyincr (float): Factor to increase asymptotes.
+        asydecr (float): Factor to decrease asymptotes.
+        asybounds (float): The bounds for the asymptotes.
+        albefa (float): Tolerance between the asymptote and bounds.
+        oscillation_tol (float): Tolerance for oscillations detection between iterations.
+    """
     asyinit: float = 0.5
     asyincr: float = 1.2
     asydecr: float = 0.7

--- a/sao/solvers/method_of_moving_asymptotes.py
+++ b/sao/solvers/method_of_moving_asymptotes.py
@@ -1,15 +1,13 @@
 from sao.problems import Subproblem
 from sao.approximations import Taylor1
-from sao.intervening_variables import MMA
+from sao.intervening_variables import MMA, MMAOptions
 from sao.move_limits import Bounds, MoveLimit, AdaptiveMoveLimit
 from sao.convergence_criteria.criteria import VariableChange
 from sao.solvers.primal_dual_interior_point import pdip
 
 
-def mma(problem, x0=None, move=0.2, xmin=0.0, xmax=1.0, asyinit=0.5, asyincr=1.2, asydecr=0.7, asybound=10.0,
-        albefa=0.1, oscillation_tol=1e-10, stop_tol=1e-6):
-    int_variable = MMA(xmin=xmin, xmax=xmax, asyinit=asyinit, asyincr=asyincr, asydecr=asydecr, asybound=asybound,
-                       albefa=albefa, oscillation_tol=oscillation_tol)
+def mma(problem, x0=None, move=0.2, xmin=0.0, xmax=1.0, options=MMAOptions(), stop_tol=1e-6):
+    int_variable = MMA(xmin=xmin, xmax=xmax, options=options)
     approx = Taylor1(int_variable)
     lim1 = Bounds(problem.x_min, problem.x_max)
     lim2 = MoveLimit(move * (problem.x_max - problem.x_min))


### PR DESCRIPTION
This combines the MMA-related options in a single dataclass. This helps in reducing the large number of optional keyword arguments for some of the MMA functions. Additionally, this makes sure there is only one definition for the default values (i.e. in the `MMAOptions` definition) rather than possible duplications inside function definitions. 

Functions can accept `options=MMAOptions()` which initialises all options to default values. As as user, you can then provide alternative settings as `options=MMAOptions(asyinit=value, asydecr=value)` etc. 

Maybe @Giannis1993 or @artofscience can update the documentation to better reflect their interpretation. 