### PR TITLE
Update README with SAOR description.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A problem can be setup using predefined wrappers
 ```python
 problem = Square()
 x, f = sao.solvers.method_of_moving_asymptoptes.mma(problem, x0=x0)
-print(f'Final design: {x} with objective value: {f}')
+print(f'Final design: {x} with objective: {f[0]} and constraints: {f[1:]}')
 ```
 
 Or by constructing the full optimization strategy
@@ -38,7 +38,7 @@ while not criterion.converged:
     sub_problem.build(x, f, df)
     x[:] = sao.solvers.primal_dual_interior_point.pdip(sub_problem)
 
-print(f'Final design: {x} with objective value: {f}')
+print(f'Final design: {x} with objective: {f} and constraints: {f[1:]}')
 ```
 
 Many alternative variations are illustrated in

--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@ package aims to provide a simple, modular implementation that enables users to
 investigate and modify the optimization routines to match their optimization
 problems.
 
-SAOR provides multiple well-known algorithms, e.g. *Optimality Criteria*,
-[*ConLin*](https://mecheng.iisc.ac.in/suresh/me256/conlin.pdf), and the
-[*Method of Moving Asymptotes (MMA)*](https://fab.cba.mit.edu/classes/865.18/design/optimization/mma.pdf).
+SAOR provides multiple well-known algorithms, e.g.
+*Optimality Criteria* ([Venkayya 1989](https://doi.org/10.1007/BF01046875)),
+*ConLin* ([Fleury, 1989](https://doi.org/10.1007/BF01637664)), and the
+*Method of Moving Asymptotes (MMA)* ([K. Svanberg, 1987](https://doi.org/10.1002/nme.1620240207)).
 Although these are implemented in a modular fashion, simple wrappers are
 provided to use a standard implementation with corresponding default settings.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,49 @@
-# SAO
+# SAOR
 
-SAO framework
+The Sequential Approximate Optimization Repository, or SAOR, provides an concise
+implementation of multiple sequential approximate optimization routines. The
+package aims to provide a simple, modular implementation that enables users to
+investigate and modify the optimization routines to match their optimization
+problems.
+
+SAOR provides multiple well-known algorithms, e.g. *Optimality Criteria*,
+[*ConLin*](https://mecheng.iisc.ac.in/suresh/me256/conlin.pdf), and the
+[*Method of Moving Asymptotes (MMA)*](https://fab.cba.mit.edu/classes/865.18/design/optimization/mma.pdf).
+Although these are implemented in a modular fashion, simple wrappers are
+provided to use a standard implementation with corresponding default settings.
+
+## Usage
+
+A problem can be setup using predefined wrappers
+
+```python
+problem = Square()
+x, f = sao.solvers.method_of_moving_asymptoptes.mma(problem, x0=x0)
+print(f'Final design: {x} with objective value: {f}')
+```
+
+Or by constructing the full optimization strategy
+
+```python
+problem = Square()
+x = problem.x0
+intervening_variables = sao.intervening_variables.MMA()
+approximation = sao.approximation.Taylor1(intervening_variables)
+sub_problem = sao.problems.Subproblem(problem)
+criterion = sao.convergence_criteria.VariableChange(x, tolerance=1e-2)
+
+while not criterion.converged:
+    f = problem.g(x)
+    df = problem.dg(x)
+    sub_problem.build(x, f, df)
+    x[:] = sao.solvers.primal_dual_interior_point.pdip(sub_problem)
+
+print(f'Final design: {x} with objective value: {f}')
+```
+
+Many alternative variations are illustrated in
+[`examples/optimization_problem_setup.py`](https://github.com/artofscience/SAOR/blob/main/examples/optimization_problem_setup.py).
+
 
 ## Installation
 


### PR DESCRIPTION
This adds a brief introduction and usage example to make our current README a bit more descriptive. Once the package and docs is hosted elsewhere, we can update the remaining sections.

Some questions:

- What do you think of the linked PDFs and do you have a suggestion for OC? 
- Should we refer directly to PDFs or prefer to link through DOIs? 
- The current examples might be a bit too concise? We can add some more context, just wondering about what problem to use as an example (`Square`?)